### PR TITLE
feat: add message handling API with CRUD operations and tests

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -31,6 +31,15 @@ type NFContext struct {
 	Tasks      []Task
 	TaskMutex  sync.RWMutex
 	NextTaskID uint64
+
+	Messages []Message
+}
+
+type Message struct {
+	ID      string `json:"id"`
+	Content string `json:"content"`
+	Author  string `json:"author"`
+	Time    string `json:"time"`
 }
 
 var nfContext = NFContext{}
@@ -75,6 +84,8 @@ func InitNfContext() {
 
 	nfContext.Tasks = make([]Task, 0)
 	nfContext.NextTaskID = 0
+
+	nfContext.Messages = make([]Message, 0)
 }
 
 func GetSelf() *NFContext {

--- a/internal/sbi/api_msg.go
+++ b/internal/sbi/api_msg.go
@@ -1,0 +1,70 @@
+package sbi
+
+import (
+	"net/http"
+
+	"github.com/Alonza0314/nf-example/internal/logger"
+	"github.com/Alonza0314/nf-example/internal/sbi/processor"
+	"github.com/gin-gonic/gin"
+)
+
+func (s *Server) getMessageRoute() []Route {
+	return []Route{
+		{
+			Name:    "Post Message",
+			Method:  http.MethodPost,
+			Pattern: "/",
+			APIFunc: s.HTTPPostMessage,
+			// Use
+			// curl -X POST http://127.0.0.163:8000/msg/ \
+			//   -H "Content-Type: application/json" \
+			//   -d '{"content":"Hello World","author":"Anya"}' -w "\n"
+		},
+		{
+			Name:    "Get All Messages",
+			Method:  http.MethodGet,
+			Pattern: "/",
+			APIFunc: s.HTTPGetMessages,
+			// Use
+			// curl -X GET http://127.0.0.163:8000/msg/ -w "\n"
+		},
+		{
+			Name:    "Get Message by ID",
+			Method:  http.MethodGet,
+			Pattern: "/:id", // ":" is used for dynamic parameter
+			APIFunc: s.HTTPGetMessageByID,
+			// Use
+			// curl -X GET http://127.0.0.163:8000/msg/{message-id} -w "\n"
+		},
+	}
+}
+
+func (s *Server) HTTPPostMessage(c *gin.Context) {
+	logger.SBILog.Infof("In HTTPPostMessage")
+
+	var req processor.PostMessageRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		logger.SBILog.Errorf("Invalid request body: %+v", err)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"message": "Invalid request body",
+			"error":   err.Error(),
+		})
+		return
+	}
+	// if req has redundant fields, it will be ignored
+	s.Processor().PostMessage(c, req)
+}
+
+func (s *Server) HTTPGetMessages(c *gin.Context) {
+	logger.SBILog.Infof("In HTTPGetMessages")
+
+	s.Processor().GetMessages(c)
+}
+
+func (s *Server) HTTPGetMessageByID(c *gin.Context) {
+	logger.SBILog.Infof("In HTTPGetMessageByID")
+
+	messageID := c.Param("id")
+
+	s.Processor().GetMessageByID(c, messageID)
+}

--- a/internal/sbi/api_msg_test.go
+++ b/internal/sbi/api_msg_test.go
@@ -1,0 +1,426 @@
+// Package sbi_test contains integration tests for the SBI (South Bound Interface) layer
+// These tests verify the HTTP API endpoints by testing the complete request-response cycle
+package sbi_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	nf_context "github.com/Alonza0314/nf-example/internal/context"
+	"github.com/Alonza0314/nf-example/internal/sbi"
+	"github.com/Alonza0314/nf-example/internal/sbi/processor"
+	"github.com/Alonza0314/nf-example/pkg/factory"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/mock/gomock"
+)
+
+// Test_HTTPPostMessage tests the HTTP POST endpoint for creating new messages
+// This function validates various scenarios including successful message creation,
+// invalid JSON handling, and missing required fields validation
+func Test_HTTPPostMessage(t *testing.T) {
+	// Set Gin to test mode to prevent debug output during testing
+	gin.SetMode(gin.TestMode)
+
+	// Create a new mock controller to manage all mock objects for this test
+	mockCtrl := gomock.NewController(t)
+
+	// Create mock objects for the NF application and processor
+	// These mocks allow us to control dependencies and isolate the code under test
+	nfApp := sbi.NewMocknfApp(mockCtrl)
+	mockProcessor := processor.NewMockProcessorNf(mockCtrl)
+
+	// Create a real processor instance that wraps the mock processor
+	// This allows us to test the actual processor logic while mocking its dependencies
+	realProcessor, err := processor.NewProcessor(mockProcessor)
+	if err != nil {
+		t.Errorf("Failed to create processor: %s", err)
+		return
+	}
+
+	// Set up expectations for mock calls that will happen during server initialization
+	// AnyTimes() allows these methods to be called any number of times during the test
+	nfApp.EXPECT().Config().Return(&factory.Config{
+		Configuration: &factory.Configuration{
+			Sbi: &factory.Sbi{
+				Port: 8000, // Mock server configuration with port 8000
+			},
+		},
+	}).AnyTimes()
+	nfApp.EXPECT().Processor().Return(realProcessor).AnyTimes()
+
+	// Create the SBI server instance with the mocked dependencies
+	server := sbi.NewServer(nfApp, "")
+
+	// Test case 1: Successful message posting
+	// This test verifies that a valid POST request creates a message successfully
+	t.Run("Post Message Successfully", func(t *testing.T) {
+		// Define the expected HTTP status code for successful message creation
+		const EXPECTED_STATUS = http.StatusCreated
+
+		// Create a sample request body with valid message data
+		// This represents the JSON payload that a client would send
+		requestBody := map[string]string{
+			"content": "Hello World", // The message content
+			"author":  "Anya",        // The message author
+		}
+
+		// Marshal the request body into JSON format
+		// This simulates how HTTP clients send JSON data
+		var jsonBody []byte
+		jsonBody, err = json.Marshal(requestBody)
+		if err != nil {
+			t.Errorf("Failed to marshal request body: %s", err)
+			return
+		}
+
+		// Set up mock context with an empty messages slice
+		// This represents the initial state before any messages are created
+		mockContext := &nf_context.NFContext{
+			Messages: []nf_context.Message{}, // Start with no existing messages
+		}
+		// Expect the Context() method to be called once during message processing
+		mockProcessor.EXPECT().Context().Return(mockContext).Times(1)
+
+		// Create HTTP test infrastructure
+		// httpRecorder captures the HTTP response for inspection
+		httpRecorder := httptest.NewRecorder()
+		// ginCtx provides the Gin context needed for HTTP handling
+		ginCtx, _ := gin.CreateTestContext(httpRecorder)
+
+		// Create a mock HTTP POST request with the JSON body
+		// This simulates a real HTTP request from a client
+		ginCtx.Request, err = http.NewRequest("POST", "/message/", bytes.NewBuffer(jsonBody))
+		if err != nil {
+			t.Errorf("Failed to create request: %s", err)
+			return
+		}
+		// Set the Content-Type header to indicate JSON payload
+		ginCtx.Request.Header.Set("Content-Type", "application/json")
+
+		// Execute the actual HTTP handler method
+		// This is the code under test - the HTTPPostMessage function
+		server.HTTPPostMessage(ginCtx)
+
+		// Verify the HTTP response status code
+		// StatusCreated (201) indicates successful resource creation
+		if httpRecorder.Code != EXPECTED_STATUS {
+			t.Errorf("Expected status code %d, got %d", EXPECTED_STATUS, httpRecorder.Code)
+		}
+
+		// Parse the JSON response body to verify its contents
+		var response map[string]interface{}
+		err = json.Unmarshal(httpRecorder.Body.Bytes(), &response)
+		if err != nil {
+			t.Errorf("Failed to unmarshal response: %s", err)
+		}
+
+		// Verify the response contains the expected success message
+		if response["message"] != "Message posted successfully" {
+			t.Errorf("Expected message 'Message posted successfully', got %s", response["message"])
+		}
+
+		// Verify the response data structure and content
+		// The response should include the created message data
+		if data, ok := response["data"].(map[string]interface{}); !ok {
+			t.Errorf("Expected data field to be an object")
+		} else {
+			// Verify that the response contains the original content
+			if data["content"] != "Hello World" {
+				t.Errorf("Expected content 'Hello World', got %s", data["content"])
+			}
+			// Verify that the response contains the original author
+			if data["author"] != "Anya" {
+				t.Errorf("Expected author 'Anya', got %s", data["author"])
+			}
+			// Verify that an ID was generated for the new message
+			if data["id"] == nil || data["id"] == "" {
+				t.Errorf("Expected non-empty ID")
+			}
+			// Verify that a timestamp was added to the message
+			if data["time"] == nil || data["time"] == "" {
+				t.Errorf("Expected non-empty time")
+			}
+		}
+	})
+
+	// Test case 2: Invalid JSON handling
+	// This test verifies that the API properly handles malformed JSON requests
+	t.Run("Post Message with Invalid JSON", func(t *testing.T) {
+		// Define expected response for invalid JSON
+		const EXPECTED_STATUS = http.StatusBadRequest
+		const EXPECTED_MESSAGE = "Invalid request body"
+
+		// Create intentionally malformed JSON (missing value after "author":)
+		// This simulates a client sending corrupted or incomplete JSON data
+		invalidJSON := []byte(`{"content": "Hello World", "author":}`)
+
+		// Set up HTTP testing infrastructure
+		httpRecorder := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(httpRecorder)
+
+		// Create request with the invalid JSON payload
+		// var err error
+		ginCtx.Request, err = http.NewRequest("POST", "/message/", bytes.NewBuffer(invalidJSON))
+		if err != nil {
+			t.Errorf("Failed to create request: %s", err)
+			return
+		}
+		ginCtx.Request.Header.Set("Content-Type", "application/json")
+
+		// Execute the handler - it should handle the invalid JSON gracefully
+		server.HTTPPostMessage(ginCtx)
+
+		// Verify that the server responds with a Bad Request status
+		if httpRecorder.Code != EXPECTED_STATUS {
+			t.Errorf("Expected status code %d, got %d", EXPECTED_STATUS, httpRecorder.Code)
+		}
+
+		// Parse and verify the error response
+		var response map[string]interface{}
+		err = json.Unmarshal(httpRecorder.Body.Bytes(), &response)
+		if err != nil {
+			t.Errorf("Failed to unmarshal response: %s", err)
+		}
+
+		// Verify the error message is descriptive
+		if response["message"] != EXPECTED_MESSAGE {
+			t.Errorf("Expected message %s, got %s", EXPECTED_MESSAGE, response["message"])
+		}
+
+		// Verify that an error field is present in the response
+		// This helps clients understand what went wrong
+		if response["error"] == nil {
+			t.Errorf("Expected error field to be present")
+		}
+	})
+
+	// Test case 3: Missing required fields validation
+	// This test ensures that requests with incomplete data are rejected properly
+	t.Run("Post Message with Missing Required Fields", func(t *testing.T) {
+		// Define expected response for incomplete request
+		const EXPECTED_STATUS = http.StatusBadRequest
+		const EXPECTED_MESSAGE = "Invalid request body"
+
+		// Create request body missing the "author" field
+		// This tests the API's input validation capabilities
+		requestBody := map[string]string{
+			"content": "Hello World", // Only content provided, author is missing
+		}
+
+		// Convert to JSON for the request
+		var jsonBody []byte
+		jsonBody, err = json.Marshal(requestBody)
+		if err != nil {
+			t.Errorf("Failed to marshal request body: %s", err)
+			return
+		}
+
+		// Set up HTTP testing infrastructure
+		httpRecorder := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(httpRecorder)
+
+		// Create request with incomplete data
+		ginCtx.Request, err = http.NewRequest("POST", "/message/", bytes.NewBuffer(jsonBody))
+		if err != nil {
+			t.Errorf("Failed to create request: %s", err)
+			return
+		}
+		ginCtx.Request.Header.Set("Content-Type", "application/json")
+
+		// Execute the handler - it should validate required fields
+		server.HTTPPostMessage(ginCtx)
+
+		// Verify that the server rejects the incomplete request
+		if httpRecorder.Code != EXPECTED_STATUS {
+			t.Errorf("Expected status code %d, got %d", EXPECTED_STATUS, httpRecorder.Code)
+		}
+
+		// Parse and verify the validation error response
+		var response map[string]interface{}
+		err = json.Unmarshal(httpRecorder.Body.Bytes(), &response)
+		if err != nil {
+			t.Errorf("Failed to unmarshal response: %s", err)
+		}
+
+		// Verify appropriate error message
+		if response["message"] != EXPECTED_MESSAGE {
+			t.Errorf("Expected message %s, got %s", EXPECTED_MESSAGE, response["message"])
+		}
+	})
+}
+
+// Test_HTTPGetMessages tests the HTTP GET endpoint for retrieving all messages
+// This function verifies that the API correctly returns the list of all stored messages
+func Test_HTTPGetMessages(t *testing.T) {
+	// Set Gin to test mode to suppress debug output
+	gin.SetMode(gin.TestMode)
+
+	// Create mock controller and dependencies
+	mockCtrl := gomock.NewController(t)
+	nfApp := sbi.NewMocknfApp(mockCtrl)
+	mockProcessor := processor.NewMockProcessorNf(mockCtrl)
+
+	// Create a real processor instance with mocked dependencies
+	realProcessor, err := processor.NewProcessor(mockProcessor)
+	if err != nil {
+		t.Errorf("Failed to create processor: %s", err)
+		return
+	}
+
+	// Set up mock expectations for server initialization
+	nfApp.EXPECT().Config().Return(&factory.Config{
+		Configuration: &factory.Configuration{
+			Sbi: &factory.Sbi{
+				Port: 8000, // Mock server configuration
+			},
+		},
+	}).AnyTimes()
+	nfApp.EXPECT().Processor().Return(realProcessor).AnyTimes()
+
+	// Initialize the SBI server with mocked dependencies
+	server := sbi.NewServer(nfApp, "")
+
+	// Test case: Successful retrieval of messages (empty list scenario)
+	// This test verifies that the API correctly handles requests when no messages exist
+	t.Run("Get Messages Successfully", func(t *testing.T) {
+		// Define expected status for successful GET request
+		const EXPECTED_STATUS = http.StatusOK
+
+		// Set up mock context with empty messages array
+		// This simulates the state when no messages have been created yet
+		mockContext := &nf_context.NFContext{
+			Messages: []nf_context.Message{}, // Empty slice represents no existing messages
+		}
+		// Expect the Context() method to be called once during message retrieval
+		mockProcessor.EXPECT().Context().Return(mockContext).Times(1)
+
+		// Set up HTTP testing infrastructure
+		httpRecorder := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(httpRecorder)
+
+		// Create a GET request to retrieve all messages
+		// No request body is needed for GET requests
+		// var err error
+		ginCtx.Request, err = http.NewRequest("GET", "/message/", nil)
+		if err != nil {
+			t.Errorf("Failed to create request: %s", err)
+			return
+		}
+
+		// Execute the GET messages handler
+		server.HTTPGetMessages(ginCtx)
+
+		// Verify that the request was successful
+		if httpRecorder.Code != EXPECTED_STATUS {
+			t.Errorf("Expected status code %d, got %d", EXPECTED_STATUS, httpRecorder.Code)
+		}
+
+		// Parse the JSON response to verify its structure
+		var response map[string]interface{}
+		err = json.Unmarshal(httpRecorder.Body.Bytes(), &response)
+		if err != nil {
+			t.Errorf("Failed to unmarshal response: %s", err)
+		}
+
+		// Verify the success message
+		if response["message"] != "Messages retrieved successfully" {
+			t.Errorf("Expected message 'Messages retrieved successfully', got %s", response["message"])
+		}
+
+		// Verify that the data field is an array (even if empty)
+		// This ensures consistent response structure regardless of message count
+		if _, ok := response["data"].([]interface{}); !ok {
+			t.Errorf("Expected data field to be an array")
+		}
+	})
+}
+
+// Test_HTTPGetMessageByID tests the HTTP GET endpoint for retrieving a specific message by ID
+// This function validates both successful retrieval and proper handling of non-existent messages
+func Test_HTTPGetMessageByID(t *testing.T) {
+	// Set Gin to test mode to prevent debug output
+	gin.SetMode(gin.TestMode)
+
+	// Create mock controller and dependencies for testing
+	mockCtrl := gomock.NewController(t)
+	nfApp := sbi.NewMocknfApp(mockCtrl)
+	mockProcessor := processor.NewMockProcessorNf(mockCtrl)
+
+	// Create a real processor instance with mocked dependencies
+	realProcessor, err := processor.NewProcessor(mockProcessor)
+	if err != nil {
+		t.Errorf("Failed to create processor: %s", err)
+		return
+	}
+
+	// Set up mock expectations for server configuration
+	nfApp.EXPECT().Config().Return(&factory.Config{
+		Configuration: &factory.Configuration{
+			Sbi: &factory.Sbi{
+				Port: 8000, // Mock server port configuration
+			},
+		},
+	}).AnyTimes()
+	nfApp.EXPECT().Processor().Return(realProcessor).AnyTimes()
+
+	// Initialize the SBI server with mocked dependencies
+	server := sbi.NewServer(nfApp, "")
+
+	// Test case: Attempting to retrieve a message that doesn't exist
+	// This test verifies proper error handling when a requested message ID is not found
+	t.Run("Get Message by Valid ID - Not Found", func(t *testing.T) {
+		// Define test parameters
+		const MESSAGE_ID = "test-message-id"        // ID that doesn't exist in the system
+		const EXPECTED_STATUS = http.StatusNotFound // 404 status for non-existent resources
+
+		// Set up mock context with no messages
+		// This simulates a scenario where the requested message doesn't exist
+		mockContext := &nf_context.NFContext{
+			Messages: []nf_context.Message{}, // Empty slice means no messages exist
+		}
+		// Expect the Context() method to be called once during message lookup
+		mockProcessor.EXPECT().Context().Return(mockContext).Times(1)
+
+		// Set up HTTP testing infrastructure
+		httpRecorder := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(httpRecorder)
+
+		// Create a GET request for a specific message ID
+		// var err error
+		ginCtx.Request, err = http.NewRequest("GET", "/message/"+MESSAGE_ID, nil)
+		if err != nil {
+			t.Errorf("Failed to create request: %s", err)
+			return
+		}
+
+		// Manually set the URL parameter for testing
+		// In a real Gin router, this would be extracted from the URL path automatically
+		// The "id" parameter corresponds to the ":id" in the route pattern "/:id"
+		ginCtx.Params = gin.Params{
+			{Key: "id", Value: MESSAGE_ID},
+		}
+
+		// Execute the handler to get message by ID
+		server.HTTPGetMessageByID(ginCtx)
+
+		// Verify that the server responds with Not Found status
+		if httpRecorder.Code != EXPECTED_STATUS {
+			t.Errorf("Expected status code %d, got %d", EXPECTED_STATUS, httpRecorder.Code)
+		}
+
+		// Parse and verify the error response
+		var response map[string]interface{}
+		err = json.Unmarshal(httpRecorder.Body.Bytes(), &response)
+		if err != nil {
+			t.Errorf("Failed to unmarshal response: %s", err)
+		}
+
+		// Verify that the response contains an appropriate error message
+		if response["message"] != "Message not found" {
+			t.Errorf("Expected message 'Message not found', got %s", response["message"])
+		}
+	})
+}

--- a/internal/sbi/processor/msg.go
+++ b/internal/sbi/processor/msg.go
@@ -1,0 +1,79 @@
+package processor
+
+import (
+	"net/http"
+	"time"
+
+	nf_context "github.com/Alonza0314/nf-example/internal/context"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+type PostMessageRequest struct {
+	Content string `json:"content" binding:"required"`
+	Author  string `json:"author" binding:"required"`
+}
+
+type PostMessageResponse struct {
+	Message string             `json:"message"`
+	Data    nf_context.Message `json:"data"`
+}
+
+type GetMessagesResponse struct {
+	Message string               `json:"message"`
+	Data    []nf_context.Message `json:"data"`
+}
+
+func (p *Processor) PostMessage(c *gin.Context, req PostMessageRequest) {
+	newMessage := nf_context.Message{
+		ID:      uuid.New().String(),
+		Content: req.Content,
+		Author:  req.Author,
+		Time:    time.Now().Format(time.RFC3339),
+	}
+
+	// add message to context
+	ctx := p.Context()
+	ctx.Messages = append(ctx.Messages, newMessage)
+
+	// return success response
+	response := PostMessageResponse{
+		Message: "Message posted successfully",
+		Data:    newMessage,
+	}
+
+	c.JSON(http.StatusCreated, response)
+}
+
+func (p *Processor) GetMessages(c *gin.Context) {
+	ctx := p.Context()
+
+	response := GetMessagesResponse{
+		Message: "Messages retrieved successfully",
+		Data:    ctx.Messages,
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+func (p *Processor) GetMessageByID(c *gin.Context, messageID string) {
+	ctx := p.Context()
+
+	// find message with specified ID
+	for _, message := range ctx.Messages {
+		if message.ID == messageID {
+			response := PostMessageResponse{
+				Message: "Message found",
+				Data:    message,
+			}
+			c.JSON(http.StatusOK, response)
+			return
+		}
+	}
+
+	// if message not found
+	c.JSON(http.StatusNotFound, gin.H{
+		"message": "Message not found",
+		"error":   "No message found with the specified ID",
+	})
+}

--- a/internal/sbi/processor/msg_test.go
+++ b/internal/sbi/processor/msg_test.go
@@ -1,0 +1,431 @@
+// Package processor_test contains unit tests for the processor layer
+// These tests focus on business logic validation, data processing, and core functionality
+// The processor layer handles the actual message operations after HTTP parsing is complete
+package processor_test
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	nf_context "github.com/Alonza0314/nf-example/internal/context"
+	"github.com/Alonza0314/nf-example/internal/sbi/processor"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	gomock "go.uber.org/mock/gomock"
+)
+
+// Test_PostMessage tests the core business logic for creating new messages
+// This test focuses on the processor layer functionality, including data validation,
+// ID generation, timestamp creation, and proper storage in the context
+func Test_PostMessage(t *testing.T) {
+	// Set Gin to test mode to suppress debug output during testing
+	gin.SetMode(gin.TestMode)
+
+	// Create a mock controller to manage mock object lifecycles
+	mockCtrl := gomock.NewController(t)
+
+	// Create a mock ProcessorNf interface to isolate the processor logic being tested
+	// This allows us to control the Context() method behavior without real dependencies
+	processorNf := processor.NewMockProcessorNf(mockCtrl)
+
+	// Create the actual processor instance with the mocked dependencies
+	// This is the system under test - we test the real processor logic
+	p, err := processor.NewProcessor(processorNf)
+	if err != nil {
+		t.Errorf("Failed to create processor: %s", err)
+		return
+	}
+
+	// Test case: Successful message creation with all business logic validation
+	// This test verifies ID generation, timestamp creation, and data persistence
+	t.Run("Post Message Successfully", func(t *testing.T) {
+		// Define expected test outcomes
+		const EXPECTED_STATUS = 201                            // HTTP Created status
+		const INPUT_CONTENT = "Hello World"                    // Test message content
+		const INPUT_AUTHOR = "Anya"                            // Test message author
+		const EXPECTED_MESSAGE = "Message posted successfully" // Expected success message
+
+		// Set up mock context with empty messages array
+		// This represents the initial state before any messages are created
+		mockContext := &nf_context.NFContext{
+			Messages: []nf_context.Message{}, // Start with empty message store
+		}
+
+		// Set expectation that Context() method will be called exactly once
+		// This ensures the processor accesses the storage context as expected
+		processorNf.EXPECT().Context().Return(mockContext).Times(1)
+
+		// Set up HTTP testing infrastructure
+		// httpRecorder captures the HTTP response for verification
+		httpRecorder := httptest.NewRecorder()
+		// ginCtx provides the Gin context needed for HTTP response handling
+		ginCtx, _ := gin.CreateTestContext(httpRecorder)
+
+		// Create the request object with test data
+		// This represents the parsed and validated input from the HTTP layer
+		req := processor.PostMessageRequest{
+			Content: INPUT_CONTENT, // Message text content
+			Author:  INPUT_AUTHOR,  // Message author information
+		}
+
+		// Execute the core business logic method
+		// This is the main functionality being tested
+		p.PostMessage(ginCtx, req)
+
+		// Verify the HTTP response status code
+		// 201 Created indicates successful resource creation
+		if httpRecorder.Code != EXPECTED_STATUS {
+			t.Errorf("Expected status code %d, got %d", EXPECTED_STATUS, httpRecorder.Code)
+		}
+
+		// Parse the JSON response to verify its structure and content
+		var response processor.PostMessageResponse
+		err = json.Unmarshal(httpRecorder.Body.Bytes(), &response)
+		if err != nil {
+			t.Errorf("Failed to unmarshal response: %s", err)
+		}
+
+		// Verify the response message indicates success
+		if response.Message != EXPECTED_MESSAGE {
+			t.Errorf("Expected message %s, got %s", EXPECTED_MESSAGE, response.Message)
+		}
+
+		// Verify that the original content is preserved in the response
+		if response.Data.Content != INPUT_CONTENT {
+			t.Errorf("Expected content %s, got %s", INPUT_CONTENT, response.Data.Content)
+		}
+
+		// Verify that the original author is preserved in the response
+		if response.Data.Author != INPUT_AUTHOR {
+			t.Errorf("Expected author %s, got %s", INPUT_AUTHOR, response.Data.Author)
+		}
+
+		// Verify that a unique ID was generated for the new message
+		// IDs are essential for message identification and retrieval
+		if response.Data.ID == "" {
+			t.Errorf("Expected non-empty ID, got empty string")
+		}
+
+		// Verify that the generated ID is a valid UUID format
+		// This ensures consistent ID formatting across the system
+		_, err = uuid.Parse(response.Data.ID)
+		if err != nil {
+			t.Errorf("Expected valid UUID, got %s", response.Data.ID)
+		}
+
+		// Verify that a timestamp was automatically generated
+		// Timestamps are crucial for message ordering and audit trails
+		if response.Data.Time == "" {
+			t.Errorf("Expected non-empty time, got empty string")
+		}
+
+		// Verify that the timestamp follows RFC3339 format (ISO 8601)
+		// This ensures consistent time formatting and timezone handling
+		_, err = time.Parse(time.RFC3339, response.Data.Time)
+		if err != nil {
+			t.Errorf("Expected time in RFC3339 format, got %s", response.Data.Time)
+		}
+
+		// Verify that the message was properly stored in the context
+		// This confirms that the data persistence logic works correctly
+		if len(mockContext.Messages) != 1 {
+			t.Errorf("Expected 1 message in context, got %d", len(mockContext.Messages))
+		}
+	})
+}
+
+// Test_GetMessages tests the business logic for retrieving all stored messages
+// This test verifies data retrieval functionality and proper response formatting
+// It covers both empty state and populated state scenarios
+func Test_GetMessages(t *testing.T) {
+	// Set Gin to test mode to suppress debug output
+	gin.SetMode(gin.TestMode)
+
+	// Create mock controller for managing mock object lifecycles
+	mockCtrl := gomock.NewController(t)
+
+	// Create mock ProcessorNf interface to control dependencies
+	processorNf := processor.NewMockProcessorNf(mockCtrl)
+
+	// Create the actual processor instance being tested
+	p, err := processor.NewProcessor(processorNf)
+	if err != nil {
+		t.Errorf("Failed to create processor: %s", err)
+		return
+	}
+
+	// Test case 1: Retrieving messages when the system is empty
+	// This test verifies proper handling of the initial state with no messages
+	t.Run("Get Messages Successfully - Empty List", func(t *testing.T) {
+		// Define expected test outcomes for empty state
+		const EXPECTED_STATUS = 200                                // HTTP OK status
+		const EXPECTED_MESSAGE = "Messages retrieved successfully" // Success message
+
+		// Set up mock context representing an empty message store
+		// This simulates the system state when no messages have been created
+		mockContext := &nf_context.NFContext{
+			Messages: []nf_context.Message{}, // Empty slice represents no stored messages
+		}
+
+		// Set expectation for Context() method call
+		// The processor needs to access the context to retrieve messages
+		processorNf.EXPECT().Context().Return(mockContext).Times(1)
+
+		// Set up HTTP testing infrastructure
+		httpRecorder := httptest.NewRecorder()           // Captures HTTP response
+		ginCtx, _ := gin.CreateTestContext(httpRecorder) // Provides Gin context
+
+		// Execute the business logic method for retrieving messages
+		p.GetMessages(ginCtx)
+
+		// Verify the HTTP response status code
+		// 200 OK indicates successful data retrieval
+		if httpRecorder.Code != EXPECTED_STATUS {
+			t.Errorf("Expected status code %d, got %d", EXPECTED_STATUS, httpRecorder.Code)
+		}
+
+		// Parse and verify the JSON response structure
+		var response processor.GetMessagesResponse
+		err = json.Unmarshal(httpRecorder.Body.Bytes(), &response)
+		if err != nil {
+			t.Errorf("Failed to unmarshal response: %s", err)
+		}
+
+		// Verify the success message is present
+		if response.Message != EXPECTED_MESSAGE {
+			t.Errorf("Expected message %s, got %s", EXPECTED_MESSAGE, response.Message)
+		}
+
+		// Verify that the data array is empty but properly initialized
+		// This ensures consistent response structure even with no data
+		if len(response.Data) != 0 {
+			t.Errorf("Expected 0 messages, got %d", len(response.Data))
+		}
+	})
+
+	// Test case 2: Retrieving messages when data exists in the system
+	// This test verifies proper data serialization and response formatting with actual data
+	t.Run("Get Messages Successfully - With Data", func(t *testing.T) {
+		// Define expected outcomes for populated state
+		const EXPECTED_STATUS = 200                                // HTTP OK status
+		const EXPECTED_MESSAGE = "Messages retrieved successfully" // Success message
+
+		// Create test data representing existing messages in the system
+		// This simulates the state after messages have been created and stored
+		testMessages := []nf_context.Message{
+			{
+				ID:      "test-id-1",            // First message with unique ID
+				Content: "Test message 1",       // First message content
+				Author:  "Author 1",             // First message author
+				Time:    "2023-01-01T12:00:00Z", // First message timestamp (ISO 8601)
+			},
+			{
+				ID:      "test-id-2",            // Second message with unique ID
+				Content: "Test message 2",       // Second message content
+				Author:  "Author 2",             // Second message author
+				Time:    "2023-01-01T12:01:00Z", // Second message timestamp (1 minute later)
+			},
+		}
+
+		// Set up mock context with the test data
+		// This represents a populated message store with existing messages
+		mockContext := &nf_context.NFContext{
+			Messages: testMessages, // Pre-populated message slice
+		}
+
+		// Set expectation for Context() method access
+		processorNf.EXPECT().Context().Return(mockContext).Times(1)
+
+		// Set up HTTP testing infrastructure
+		httpRecorder := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(httpRecorder)
+
+		// Execute the message retrieval business logic
+		p.GetMessages(ginCtx)
+
+		// Verify successful HTTP response
+		if httpRecorder.Code != EXPECTED_STATUS {
+			t.Errorf("Expected status code %d, got %d", EXPECTED_STATUS, httpRecorder.Code)
+		}
+
+		// Parse and verify the JSON response with actual data
+		var response processor.GetMessagesResponse
+		err = json.Unmarshal(httpRecorder.Body.Bytes(), &response)
+		if err != nil {
+			t.Errorf("Failed to unmarshal response: %s", err)
+		}
+
+		// Verify success message
+		if response.Message != EXPECTED_MESSAGE {
+			t.Errorf("Expected message %s, got %s", EXPECTED_MESSAGE, response.Message)
+		}
+
+		// Verify that the correct number of messages are returned
+		// This ensures all stored messages are properly retrieved
+		if len(response.Data) != 2 {
+			t.Errorf("Expected 2 messages, got %d", len(response.Data))
+		}
+
+		// Verify the first message data integrity
+		// This ensures the data is correctly serialized and ordered
+		if response.Data[0].ID != "test-id-1" {
+			t.Errorf("Expected first message ID test-id-1, got %s", response.Data[0].ID)
+		}
+
+		// Verify the second message content integrity
+		// This confirms that all message fields are properly preserved
+		if response.Data[1].Content != "Test message 2" {
+			t.Errorf("Expected second message content 'Test message 2', got %s", response.Data[1].Content)
+		}
+	})
+}
+
+// Test_GetMessageByID tests the business logic for retrieving a specific message by its ID
+// This test validates message lookup functionality, including both successful retrieval
+// and proper error handling for non-existent messages
+func Test_GetMessageByID(t *testing.T) {
+	// Set Gin to test mode to suppress debug output
+	gin.SetMode(gin.TestMode)
+
+	// Create mock controller for managing mock objects
+	mockCtrl := gomock.NewController(t)
+
+	// Create mock ProcessorNf interface for dependency control
+	processorNf := processor.NewMockProcessorNf(mockCtrl)
+
+	// Create the processor instance being tested
+	p, err := processor.NewProcessor(processorNf)
+	if err != nil {
+		t.Errorf("Failed to create processor: %s", err)
+		return
+	}
+
+	// Set up test data representing existing messages in the system
+	// This data will be used across multiple test scenarios
+	testMessages := []nf_context.Message{
+		{
+			ID:      "existing-id",          // First test message with known ID
+			Content: "Existing message",     // Content for verification
+			Author:  "Test Author",          // Author for verification
+			Time:    "2023-01-01T12:00:00Z", // Timestamp in ISO 8601 format
+		},
+		{
+			ID:      "another-id",           // Second test message with different ID
+			Content: "Another message",      // Different content for testing
+			Author:  "Another Author",       // Different author for testing
+			Time:    "2023-01-01T12:01:00Z", // Later timestamp
+		},
+	}
+
+	// Test case 1: Successfully finding and retrieving an existing message
+	// This test verifies the happy path where the requested message exists
+	t.Run("Find Message That Exists", func(t *testing.T) {
+		// Define test parameters for successful lookup
+		const INPUT_ID = "existing-id"           // ID that exists in our test data
+		const EXPECTED_STATUS = 200              // HTTP OK status for successful retrieval
+		const EXPECTED_MESSAGE = "Message found" // Success message
+
+		// Set up mock context with the test messages
+		// This simulates a populated message store containing our target message
+		mockContext := &nf_context.NFContext{
+			Messages: testMessages, // Use the predefined test data
+		}
+
+		// Set expectation for Context() method call during message lookup
+		processorNf.EXPECT().Context().Return(mockContext).Times(1)
+
+		// Set up HTTP testing infrastructure
+		httpRecorder := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(httpRecorder)
+
+		// Execute the message lookup business logic
+		// This tests the core ID-based search functionality
+		p.GetMessageByID(ginCtx, INPUT_ID)
+
+		// Verify successful HTTP response status
+		if httpRecorder.Code != EXPECTED_STATUS {
+			t.Errorf("Expected status code %d, got %d", EXPECTED_STATUS, httpRecorder.Code)
+		}
+
+		// Parse the JSON response to verify message data integrity
+		var response processor.PostMessageResponse
+		err = json.Unmarshal(httpRecorder.Body.Bytes(), &response)
+		if err != nil {
+			t.Errorf("Failed to unmarshal response: %s", err)
+		}
+
+		// Verify the success message
+		if response.Message != EXPECTED_MESSAGE {
+			t.Errorf("Expected message %s, got %s", EXPECTED_MESSAGE, response.Message)
+		}
+
+		// Verify that the correct message was retrieved by checking the ID
+		if response.Data.ID != INPUT_ID {
+			t.Errorf("Expected ID %s, got %s", INPUT_ID, response.Data.ID)
+		}
+
+		// Verify that the message content matches the expected data
+		// This ensures the entire message object was correctly retrieved
+		if response.Data.Content != "Existing message" {
+			t.Errorf("Expected content 'Existing message', got %s", response.Data.Content)
+		}
+
+		// Verify that the message author matches the expected data
+		// This confirms all message fields are properly preserved
+		if response.Data.Author != "Test Author" {
+			t.Errorf("Expected author 'Test Author', got %s", response.Data.Author)
+		}
+	})
+
+	// Test case 2: Handling requests for non-existent messages
+	// This test verifies proper error handling when the requested message ID doesn't exist
+	t.Run("Find Message That Does Not Exist", func(t *testing.T) {
+		// Define test parameters for failed lookup scenario
+		const INPUT_ID = "non-existing-id"                              // ID that doesn't exist in test data
+		const EXPECTED_STATUS = 404                                     // HTTP Not Found status
+		const EXPECTED_MESSAGE = "Message not found"                    // Error message for user
+		const EXPECTED_ERROR = "No message found with the specified ID" // Detailed error description
+
+		// Set up mock context with the existing test messages
+		// The requested ID will not be found in this dataset
+		mockContext := &nf_context.NFContext{
+			Messages: testMessages, // Same test data, but won't contain the requested ID
+		}
+
+		// Set expectation for Context() method call during failed lookup
+		processorNf.EXPECT().Context().Return(mockContext).Times(1)
+
+		// Set up HTTP testing infrastructure
+		httpRecorder := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(httpRecorder)
+
+		// Execute the message lookup with non-existent ID
+		// This tests the error handling path in the business logic
+		p.GetMessageByID(ginCtx, INPUT_ID)
+
+		// Verify that the response indicates resource not found
+		if httpRecorder.Code != EXPECTED_STATUS {
+			t.Errorf("Expected status code %d, got %d", EXPECTED_STATUS, httpRecorder.Code)
+		}
+
+		// Parse the error response to verify proper error formatting
+		var response map[string]interface{}
+		err = json.Unmarshal(httpRecorder.Body.Bytes(), &response)
+		if err != nil {
+			t.Errorf("Failed to unmarshal response: %s", err)
+		}
+
+		// Verify that the error message is user-friendly and informative
+		if response["message"] != EXPECTED_MESSAGE {
+			t.Errorf("Expected message %s, got %s", EXPECTED_MESSAGE, response["message"])
+		}
+
+		// Verify that detailed error information is provided
+		// This helps with debugging and provides context to API consumers
+		if response["error"] != EXPECTED_ERROR {
+			t.Errorf("Expected error %s, got %s", EXPECTED_ERROR, response["error"])
+		}
+	})
+}

--- a/internal/sbi/router.go
+++ b/internal/sbi/router.go
@@ -51,6 +51,9 @@ func newRouter(s *Server) *gin.Engine {
 	taskGroup := router.Group("/task")
 	applyRoutes(taskGroup, s.getTaskRoute())
 
+	messageGroup := router.Group("/msg") // add for lab6
+	applyRoutes(messageGroup, s.getMessageRoute())
+
 	return router
 }
 


### PR DESCRIPTION
Lab6 exercise
## Summary

This PR implements POST \& GET message APIs for the nf-example project, adding HTTP endpoints for creating and retrieving.

## Key Features Added

### 1\. Message Data Structure

* Added `Message` struct to NFContext with fields:

  * `ID`: Unique identifier (UUID)
  * `Content`: Message content
  * `Author`: Message author
  * `Time`: Creation timestamp (RFC3339 format)

* Initialized message storage in context

### 2\. HTTP API Endpoints

* **POST /msg/**: Create new message

  * Validates required fields (content, author)
  * Generates unique UUID and timestamp
  * Returns created message data

* **GET /msg/**: Retrieve all messages

  * Returns array of all stored messages

* **GET /msg/:id**: Retrieve specific message by ID

  * Returns single message or 404 if not found

### 3\. Request/Response Handling

* Proper JSON request validation
* Structured response format with message and data fields
* Appropriate HTTP status codes (201, 200, 404, 400)
* Error handling for invalid requests

### 4\. Unit Tests

* **API Layer Tests** (`api_msg_test.go`):

  * POST endpoint: successful creation, invalid JSON, missing fields
  * GET endpoints: successful retrieval, empty results, not found scenarios

* **Processor Layer Tests** (`msg_test.go`):

  * Message creation with UUID validation
  * Message retrieval with data verification

### 5\. Router Integration

* Added message route group to main router
* Integrated with existing SBI server structure

## Files Modified

* `internal/context/context.go`: Added Message struct and storage
* `internal/sbi/router.go`: Added message route group

## Files Added

* `internal/sbi/api_msg.go`: HTTP endpoint handlers
* `internal/sbi/api_msg_test.go`: API layer tests
* `internal/sbi/processor/msg.go`: Business logic processors
* `internal/sbi/processor/msg_test.go`: Processor layer tests

## Usage Examples

```bash
# Create a message
curl -X POST http://127.0.0.163:8000/msg/ \
  -H "Content-Type: application/json" \
  -d '{"content":"Hello World","author":"Anya"}'

# Get all messages
curl -X GET http://127.0.0.163:8000/msg/

# Get specific message
curl -X GET http://127.0.0.163:8000/msg/{message-id}
```

