### PR TITLE
Laboratorio 6 (sergio) feat: add student API service with GET and POST

### DIFF
--- a/internal/sbi/api_student.go
+++ b/internal/sbi/api_student.go
@@ -1,0 +1,61 @@
+package sbi
+
+import (
+    "net/http"
+
+    "github.com/gin-gonic/gin"
+)
+
+// Rutas para el nuevo servicio /student
+func (s *Server) getStudentRoute() []Route {
+    return []Route{
+        {
+            Name:   "GetStudent",
+            Method: http.MethodGet,
+            Pattern: "/:id",
+            APIFunc: s.HTTPGetStudent,
+        },
+        {
+            Name:   "CreateStudent",
+            Method: http.MethodPost,
+            Pattern: "/",
+            APIFunc: s.HTTPCreateStudent,
+        },
+    }
+}
+
+// Estructura para el cuerpo del POST
+type Student struct {
+    ID   string `json:"id" binding:"required"`
+    Name string `json:"name" binding:"required"`
+}
+
+// GET /student/:id
+func (s *Server) HTTPGetStudent(c *gin.Context) {
+    id := c.Param("id")
+    if id == "" {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "id is required"})
+        return
+    }
+
+    c.JSON(http.StatusOK, gin.H{
+        "id":   id,
+        "name": "Student " + id,
+        "msg":  "Student info from nf-example",
+    })
+}
+
+// POST /student/
+func (s *Server) HTTPCreateStudent(c *gin.Context) {
+    var student Student
+
+    if err := c.ShouldBindJSON(&student); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+        return
+    }
+
+    c.JSON(http.StatusCreated, gin.H{
+        "msg":     "Student created successfully",
+        "student": student,
+    })
+}

--- a/internal/sbi/router.go
+++ b/internal/sbi/router.go
@@ -44,6 +44,10 @@ func newRouter(s *Server) *gin.Engine {
 
 	spyFamilyGroup := router.Group("/spyfamily")
 	applyRoutes(spyFamilyGroup, s.getSpyFamilyRoute())
+        
+        studentGroup := router.Group("/student")
+        applyRoutes(studentGroup, s.getStudentRoute())
+
 
 	return router
 }


### PR DESCRIPTION
This pull request implements the Lab 6 task for nf-example.

Changes:
- Added a new `/student` API group following the existing NF structure.
- Implemented `GET /student/:id` endpoint that returns basic student information in JSON.
- Implemented `POST /student/` endpoint that receives `{"id","name"}` in JSON and returns the created student.

Testing:
- `make`
- `./bin/nf -c config/nfcfg.yaml`
- `curl -X GET http://127.0.0.163:8000/default/`
- `curl -X GET http://127.0.0.163:8000/student/123`
- `curl -X POST http://127.0.0.163:8000/student/ -H "Content-Type: application/json" -d '{"id":"1","name":"Sergio"}'`
