### PR TITLE
feat: add custom API service (GET/POST)

### DIFF
--- a/internal/sbi/custom/custom.go
+++ b/internal/sbi/custom/custom.go
@@ -1,0 +1,23 @@
+package custom
+
+import (
+    "github.com/gin-gonic/gin"
+    "net/http"
+)
+
+func AddCustomService(r *gin.Engine) {
+    r.GET("/custom/hello", func(c *gin.Context) {
+        c.JSON(http.StatusOK, gin.H{
+            "message": "Hello from Evelin’s custom API!",
+        })
+    })
+
+    r.POST("/custom/echo", func(c *gin.Context) {
+        var data map[string]interface{}
+        c.BindJSON(&data)
+        c.JSON(http.StatusOK, gin.H{
+            "received": data,
+        })
+    })
+}
+

--- a/internal/sbi/router.go
+++ b/internal/sbi/router.go
@@ -1,9 +1,9 @@
 package sbi
-
+import "nf-example/internal/sbi/custom"
 import (
 	"fmt"
 	"net/http"
-
+        "github.com/omatabajoy/nf-example/internal/sbi/custom" 
 	"github.com/Alonza0314/nf-example/internal/logger"
 	"github.com/Alonza0314/nf-example/pkg/app"
 	"github.com/gin-gonic/gin"
@@ -37,15 +37,18 @@ func applyRoutes(group *gin.RouterGroup, routes []Route) {
 }
 
 func newRouter(s *Server) *gin.Engine {
-	router := logger_util.NewGinWithLogrus(logger.GinLog)
+    router := logger_util.NewGinWithLogrus(logger.GinLog)
 
-	defaultGroup := router.Group("/default")
-	applyRoutes(defaultGroup, s.getDefaultRoute())
+    defaultGroup := router.Group("/default")
+    applyRoutes(defaultGroup, s.getDefaultRoute())
 
-	spyFamilyGroup := router.Group("/spyfamily")
-	applyRoutes(spyFamilyGroup, s.getSpyFamilyRoute())
+    spyFamilyGroup := router.Group("/spyfamily")
+    applyRoutes(spyFamilyGroup, s.getSpyFamilyRoute())
 
-	return router
+    // Agregar tu custom API
+    custom.AddCustomService(router)
+
+    return router
 }
 
 func bindRouter(nf app.App, router *gin.Engine, tlsKeyLogPath string) (*http.Server, error) {


### PR DESCRIPTION
This PR adds a custom API service with one GET endpoint and one POST endpoint as required by Lab 6.
Includes:
- custom.go with GetHello and PostEcho handlers
- Router updated to expose new endpoints under /custom
