### PR TITLE
feat: add new API service with GET and POST endpoints

### DIFF
--- a/internal/newapi/handler.go
+++ b/internal/newapi/handler.go
@@ -1,0 +1,29 @@
+package newapi
+
+import (
+    "net/http"
+    "github.com/gin-gonic/gin"
+)
+
+func GetMessage(c *gin.Context) {
+    c.JSON(http.StatusOK, gin.H{
+        "message": "Hola desde el nuevo GET!",
+    })
+}
+
+type CreateRequest struct {
+    Name string `json:"name"`
+}
+
+func CreateItem(c *gin.Context) {
+    var req CreateRequest
+    if err := c.BindJSON(&req); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid input"})
+        return
+    }
+
+    c.JSON(http.StatusCreated, gin.H{
+        "status": "created",
+        "name": req.Name,
+    })
+}

--- a/internal/sbi/api_secondapi.go
+++ b/internal/sbi/api_secondapi.go
@@ -1,0 +1,22 @@
+package sbi
+
+import (
+    "github.com/gabbyrz024/nf-example/internal/secondapi"
+)
+
+func (s *Server) getSecondAPIRoute() []Route {
+    return []Route{
+        {
+            Name:    "secondapi-status",
+            Method:  "GET",
+            Pattern: "/status",
+            APIFunc: secondapi.GetStatus,
+        },
+        {
+            Name:    "secondapi-message",
+            Method:  "POST",
+            Pattern: "/message",
+            APIFunc: secondapi.PostMessage,
+        },
+    }
+}

--- a/internal/sbi/router.go
+++ b/internal/sbi/router.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/free5gc/util/httpwrapper"
 	logger_util "github.com/free5gc/util/logger"
+
+       "github.com/gabbyrz024/nf-example/internal/secondapi"
 )
 
 type Route struct {
@@ -44,6 +46,9 @@ func newRouter(s *Server) *gin.Engine {
 
 	spyFamilyGroup := router.Group("/spyfamily")
 	applyRoutes(spyFamilyGroup, s.getSpyFamilyRoute())
+
+    	secondAPIGroup := router.Group("/secondapi")
+	applyRoutes(secondAPIGroup, s.getSecondAPIRoute())
 
 	return router
 }

--- a/internal/secondapi/handler.go
+++ b/internal/secondapi/handler.go
@@ -1,0 +1,31 @@
+package secondapi
+
+import (
+    "net/http"
+
+    "github.com/gin-gonic/gin"
+)
+
+func GetStatus(c *gin.Context) {
+    c.JSON(http.StatusOK, gin.H{
+        "status": "second api running",
+    })
+}
+
+type MessageRequest struct {
+    Message string `json:"message"`
+}
+
+func PostMessage(c *gin.Context) {
+    var req MessageRequest
+    if err := c.BindJSON(&req); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{
+            "error": err.Error(),
+        })
+        return
+    }
+
+    c.JSON(http.StatusOK, gin.H{
+        "received": req.Message,
+    })
+}

--- a/secondapi/handler.go
+++ b/secondapi/handler.go
@@ -1,0 +1,31 @@
+package secondapi
+
+import (
+    "net/http"
+
+    "github.com/gin-gonic/gin"
+)
+
+func GetStatus(c *gin.Context) {
+    c.JSON(http.StatusOK, gin.H{
+        "status": "second api running",
+    })
+}
+
+type MessageRequest struct {
+    Message string `json:"message"`
+}
+
+func PostMessage(c *gin.Context) {
+    var req MessageRequest
+    if err := c.BindJSON(&req); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{
+            "error": err.Error(),
+        })
+        return
+    }
+
+    c.JSON(http.StatusOK, gin.H{
+        "received": req.Message,
+    })
+}


### PR DESCRIPTION
This PR adds a new API service following the NF structure as required in Lab 6.
It includes:
- One GET endpoint
- One POST endpoint
- New handler files
- Router updates to register the new API
- Proper branch naming and conventional commit message

Ready for review.
