### PR TITLE
feat: add practice API service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: Go CI Pipeline
+
+on:
+  push:
+    branches:
+      - main
+      - feature/**
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.5'
+
+      - name: Download dependencies
+        run: go mod tidy
+
+      - name: Build project
+        run: go build ./...

--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,29 @@
+name: Go CI Pipeline
+
+on:
+  push:
+    branches:
+      - main
+      - feature/**
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25.5'
+
+      - name: Download dependencies
+        run: go mod tidy
+
+      - name: Build project
+        run: go build ./...

--- a/internal/sbi/api_practice.go
+++ b/internal/sbi/api_practice.go
@@ -1,0 +1,50 @@
+package sbi
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type PracticeRequest struct {
+	Name string `json:"name"`
+}
+
+func (s *Server) getPracticeRoute() []Route {
+	return []Route{
+		{
+			Name:    "GetPractice",
+			Method:  "GET",
+			Pattern: "/list",
+			APIFunc: GetPractice,
+		},
+		{
+			Name:    "CreatePractice",
+			Method:  "POST",
+			Pattern: "/create",
+			APIFunc: CreatePractice,
+		},
+	}
+}
+
+func GetPractice(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Practice API is working",
+	})
+}
+
+func CreatePractice(c *gin.Context) {
+	var body PracticeRequest
+
+	if err := c.BindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "Task created",
+		"name":    body.Name,
+	})
+}

--- a/internal/sbi/router.go
+++ b/internal/sbi/router.go
@@ -1,3 +1,4 @@
+
 package sbi
 
 import (
@@ -45,6 +46,9 @@ func newRouter(s *Server) *gin.Engine {
 	spyFamilyGroup := router.Group("/spyfamily")
 	applyRoutes(spyFamilyGroup, s.getSpyFamilyRoute())
 
+        practiceGroup :=router.Group("/practice")
+        applyRoutes(practiceGroup, s.getPracticeRoute())
+
 	return router
 }
 
@@ -53,3 +57,4 @@ func bindRouter(nf app.App, router *gin.Engine, tlsKeyLogPath string) (*http.Ser
 	bindAddr := fmt.Sprintf("%s:%d", sbiConfig.BindingIPv4, sbiConfig.Port)
 	return httpwrapper.NewHttp2Server(bindAddr, tlsKeyLogPath, router)
 }
+


### PR DESCRIPTION
Added a new Practice API service to the NF example project.

Implemented:

* GET endpoint to retrieve practice information
* POST endpoint to create practice data
* Route registration in router.go

This follows the project structure and conventional commit guidelines.
