### PR TITLE
feat: add lab6 api service

### DIFF
--- a/internal/sbi/api_lab6.go
+++ b/internal/sbi/api_lab6.go
@@ -1,0 +1,49 @@
+package sbi
+
+import (
+	"net/http"
+
+	"github.com/Alonza0314/nf-example/internal/logger"
+	"github.com/gin-gonic/gin"
+)
+
+type Lab6MessageRequest struct {
+	Sender  string `json:"sender"`
+	Message string `json:"message"`
+}
+
+func (s *Server) getLab6Route() []Route {
+	return []Route{
+		{
+			Name:    "Lab6 Status",
+			Method:  http.MethodGet,
+			Pattern: "/status",
+			APIFunc: s.HTTPGetLab6Status,
+		},
+		{
+			Name:    "Lab6 Message",
+			Method:  http.MethodPost,
+			Pattern: "/message",
+			APIFunc: s.HTTPCreateLab6Message,
+		},
+	}
+}
+
+func (s *Server) HTTPGetLab6Status(c *gin.Context) {
+	logger.SBILog.Infof("In HTTPGetLab6Status")
+	s.Processor().GetLab6Status(c)
+}
+
+func (s *Server) HTTPCreateLab6Message(c *gin.Context) {
+	logger.SBILog.Infof("In HTTPCreateLab6Message")
+
+	var request Lab6MessageRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "invalid JSON body",
+		})
+		return
+	}
+
+	s.Processor().CreateLab6Message(c, request.Sender, request.Message)
+}

--- a/internal/sbi/processor/lab6.go
+++ b/internal/sbi/processor/lab6.go
@@ -1,0 +1,36 @@
+package processor
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (p *Processor) GetLab6Status(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"service":     "lab6",
+		"status":      "running",
+		"description": "Lab 6 API service for Git and GitHub practice",
+	})
+}
+
+func (p *Processor) CreateLab6Message(c *gin.Context, sender string, message string) {
+	sender = strings.TrimSpace(sender)
+	message = strings.TrimSpace(message)
+
+	if sender == "" || message == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "sender and message are required",
+		})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"service":    "lab6",
+		"sender":     sender,
+		"message":    message,
+		"receivedAt": time.Now().UTC().Format(time.RFC3339),
+	})
+}

--- a/internal/sbi/router.go
+++ b/internal/sbi/router.go
@@ -45,6 +45,9 @@ func newRouter(s *Server) *gin.Engine {
 	spyFamilyGroup := router.Group("/spyfamily")
 	applyRoutes(spyFamilyGroup, s.getSpyFamilyRoute())
 
+	lab6Group := router.Group("/lab6")
+	applyRoutes(lab6Group, s.getLab6Route())
+
 	return router
 }
 


### PR DESCRIPTION
## Summary
This PR adds a new Lab 6 API service following the existing nf-example structure.

## Added endpoints
- GET /lab6/status
- POST /lab6/message

## Validation
- make
- go test -v ./...
- curl GET /lab6/status
- curl POST /lab6/message

## Purpose
This change was made as part of free5GLabs Lab 6 to practice Git, GitHub, branch naming, Conventional Commits, and Pull Request workflow.