### PR TITLE
feat: add network device api service

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -16,7 +16,7 @@ type NFContext struct {
 	UriScheme   models.UriScheme
 	BindingIPv4 string
 	SBIPort     int
-
+	NetworkData map[string]string
 	SpyFamilyData map[string]string
 }
 
@@ -56,6 +56,16 @@ func InitNfContext() {
 		"Emile":  "Elman",
 		"Henry":  "Henderson",
 		"Martha": "Marriott",
+	}
+	nfContext.NetworkData = map[string]string{
+		"Router-Core-01":   "Core Router",
+		"Switch-Access-01": "Access Switch",
+		"Switch-Dist-01":   "Distribution Switch",
+		"AP-Floor-01":      "Access Point",
+		"Firewall-01":      "Firewall",
+		"gNB-Site-01":      "5G Base Station",
+		"UPF-Node-01":      "User Plane Function",
+		"AMF-Node-01":      "Access Mobility Function",
 	}
 }
 

--- a/internal/sbi/api_network.go
+++ b/internal/sbi/api_network.go
@@ -1,0 +1,65 @@
+package sbi
+
+import (
+	"net/http"
+
+	"github.com/Alonza0314/nf-example/internal/logger"
+	"github.com/gin-gonic/gin"
+)
+
+func (s *Server) getNetworkRoute() []Route {
+	return []Route{
+		{
+			Name:    "Hello Network!",
+			Method:  http.MethodGet,
+			Pattern: "/",
+			APIFunc: func(c *gin.Context) {
+				c.JSON(http.StatusOK, "Network Device API")
+			},
+		},
+		{
+			Name:    "Get Network Device",
+			Method:  http.MethodGet,
+			Pattern: "/device/:Name",
+			APIFunc: s.HTTPGetNetworkDevice,
+		},
+		{
+			Name:    "Add Network Device",
+			Method:  http.MethodPost,
+			Pattern: "/device",
+			APIFunc: s.HTTPPostNetworkDevice,
+		},
+	}
+}
+
+func (s *Server) HTTPGetNetworkDevice(c *gin.Context) {
+	logger.SBILog.Infof("In HTTPGetNetworkDevice")
+
+	targetName := c.Param("Name")
+	if targetName == "" {
+		c.String(http.StatusBadRequest, "No device name provided")
+		return
+	}
+
+	s.Processor().FindNetworkDevice(c, targetName)
+}
+
+func (s *Server) HTTPPostNetworkDevice(c *gin.Context) {
+	logger.SBILog.Infof("In HTTPPostNetworkDevice")
+
+	type RequestBody struct {
+		Name string `json:"name"`
+		Type string `json:"type"`
+	}
+	var body RequestBody
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if body.Name == "" || body.Type == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "name and type are required"})
+		return
+	}
+
+	s.Processor().AddNetworkDevice(c, body.Name, body.Type)
+}

--- a/internal/sbi/processor/network.go
+++ b/internal/sbi/processor/network.go
@@ -1,0 +1,35 @@
+package processor
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (p *Processor) FindNetworkDevice(c *gin.Context, targetName string) {
+	if deviceType, ok := p.Context().NetworkData[targetName]; ok {
+		c.JSON(http.StatusOK, gin.H{
+			"name": targetName,
+			"type": deviceType,
+		})
+		return
+	}
+	c.JSON(http.StatusNotFound, gin.H{
+		"error": fmt.Sprintf("device [%s] not found", targetName),
+	})
+}
+
+func (p *Processor) AddNetworkDevice(c *gin.Context, name string, deviceType string) {
+	if _, ok := p.Context().NetworkData[name]; ok {
+		c.JSON(http.StatusConflict, gin.H{
+			"error": fmt.Sprintf("device [%s] already exists", name),
+		})
+		return
+	}
+	p.Context().NetworkData[name] = deviceType
+	c.JSON(http.StatusCreated, gin.H{
+		"name": name,
+		"type": deviceType,
+	})
+}

--- a/internal/sbi/router.go
+++ b/internal/sbi/router.go
@@ -44,6 +44,9 @@ func newRouter(s *Server) *gin.Engine {
 
 	spyFamilyGroup := router.Group("/spyfamily")
 	applyRoutes(spyFamilyGroup, s.getSpyFamilyRoute())
+	
+	networkGroup := router.Group("/network")
+	applyRoutes(networkGroup, s.getNetworkRoute())
 
 	return router
 }


### PR DESCRIPTION
## Changes
- Add network device API service with GET and POST endpoints
- GET /network/device/:Name - retrieve a network device by name
- POST /network/device - add a new network device
- Add NetworkData to NFContext with pre-loaded network devices (routers, switches, firewalls, 5G nodes)

## Testing
- go build ./... passes successfully